### PR TITLE
Move sample image out of the Docker file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ cache:
   - data
 
 before_install: 
-  - if [ ! -f data/tubhiswt-3D/tubhiswt_C0.ome.tif ]; then wget --user-agent Travis https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-3D.zip && unzip tubhiswt-3D.zip && mv tubhiswt-3D data; fi
+  - if [ ! -f tubhiswt-2D/tubhiswt_C0.ome.tif ]; then wget --user-agent Travis https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-2D.zip && unzip tubhiswt-2D.zip; fi
   - touch "data/test&sizeT=3.fake"
   - docker build -t bio-formats-octave .
 
 script:
-- docker run -ti -v $(pwd)/data/:/data/ bio-formats-octave travis_test.m /data/tubhiswt-3D/tubhiswt_C0.ome.tif "/data/test&sizeT=3.fake"
+- docker run -ti -v $(pwd)/data/:/data/ bio-formats-octave travis_test.m /data/tubhiswt-2D/tubhiswt_C0.ome.tif
+- docker run -ti -v $(pwd)/data/:/data/ bio-formats-octave travis_test.m  "/data/test&sizeT=3.fake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   - data
 
 before_install: 
-  - if [ ! -f tubhiswt-2D/tubhiswt_C0.ome.tif ]; then wget --user-agent Travis https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-2D.zip && unzip tubhiswt-2D.zip; fi
+  - if [ ! -f tubhiswt-2D/tubhiswt_C0.ome.tif ]; then wget --user-agent Travis https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-2D.zip && unzip tubhiswt-2D.zip && mv tubhiswt-2D data; fi
   - touch "data/test&sizeT=3.fake"
   - docker build -t bio-formats-octave .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ group: deprecated-2017Q2
 services:
   - docker
 
+cache:
+  directories:
+  - tubhiswt-3D
+
 before_install: 
+  - if [ ! -f tubhiswt-3D/tubhiswt_C0.ome.tif ]; then wget --user-agent Travis https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-3D.zip && unzip tubhiswt-3D.zip; fi
   - docker build -t bio-formats-octave .
 
 script:
-- docker run -ti bio-formats-octave minimal_test.m
+- docker run -ti -v $(pwd)/tubhiswt-3D/:/data/ bio-formats-octave travis_test.m /data/tubhiswt_C0.ome.tif

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ services:
 
 cache:
   directories:
-  - tubhiswt-3D
+  - data
 
 before_install: 
-  - if [ ! -f tubhiswt-3D/tubhiswt_C0.ome.tif ]; then wget --user-agent Travis https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-3D.zip && unzip tubhiswt-3D.zip; fi
+  - if [ ! -f data/tubhiswt-3D/tubhiswt_C0.ome.tif ]; then wget --user-agent Travis https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-3D.zip && unzip tubhiswt-3D.zip && mv tubhiswt-3D data; fi
+  - touch "data/test&sizeT=3.fake"
   - docker build -t bio-formats-octave .
 
 script:
-- docker run -ti -v $(pwd)/tubhiswt-3D/:/data/ bio-formats-octave travis_test.m /data/tubhiswt_C0.ome.tif
+- docker run -ti -v $(pwd)/data/:/data/ bio-formats-octave travis_test.m /data/tubhiswt-3D/tubhiswt_C0.ome.tif "/data/test&sizeT=3.fake"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,11 @@ USER root
 RUN apt-get update && apt-get install -y wget unzip
 
 USER octave
-RUN wget downloads.openmicroscopy.org/bio-formats/$VERSION/artifacts/bioformats-octave-$VERSION.tar.gz
-RUN wget downloads.openmicroscopy.org/bio-formats/$VERSION/artifacts/bioformats_package.jar
+RUN wget --user-agent Docker downloads.openmicroscopy.org/bio-formats/$VERSION/artifacts/bioformats-octave-$VERSION.tar.gz
+RUN wget --user-agent Docker downloads.openmicroscopy.org/bio-formats/$VERSION/artifacts/bioformats_package.jar
 RUN echo "/home/octave/bioformats_package.jar" >> /home/octave/javaclasspath.txt
 
 
 RUN echo "pkg install bioformats-octave-$VERSION.tar.gz" | octave
 
-RUN wget --user-agent docker https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-3D.zip
-RUN unzip tubhiswt-3D.zip
 ADD *.m /home/octave/

--- a/test_bfopen.m
+++ b/test_bfopen.m
@@ -17,8 +17,6 @@ series1_plane1 = series1{1, 1};
 series1_label1 = series1{1, 2};
 series1_plane2 = series1{2, 1};
 series1_label2 = series1{2, 2};
-series1_plane3 = series1{3, 1};
-series1_label3 = series1{3, 2};
 % accessing-planes-end
 
 %Displaying images

--- a/travis_test.m
+++ b/travis_test.m
@@ -11,4 +11,4 @@ test_bfopen(arg_list{1});
 % Increase the debugging verbosity
 javaMethod('setRootLevel', 'loci.common.DebugTools', 'DEBUG');
 
-test_bfopen(arg_list{2});
+test_bfopen(arg_list{1});

--- a/travis_test.m
+++ b/travis_test.m
@@ -11,4 +11,4 @@ test_bfopen(arg_list{1});
 % Increase the debugging verbosity
 javaMethod('setRootLevel', 'loci.common.DebugTools', 'DEBUG');
 
-test_bfopen(arg_list{1});
+test_bfopen(arg_list{2});

--- a/travis_test.m
+++ b/travis_test.m
@@ -5,9 +5,10 @@ pkg load bioformats
 [s, v] = bfCheckJavaPath()
 bfInitLogging('INFO');
 
-test_bfopen('tubhiswt-3D/tubhiswt_C0.ome.tif');
+arg_list = argv();
+test_bfopen(arg_list{1});
 
 % Increase the debugging verbosity
 javaMethod('setRootLevel', 'loci.common.DebugTools', 'DEBUG');
 
-test_bfopen('tubhiswt-3D/tubhiswt_C0.ome.tif');
+test_bfopen(arg_list{1});


### PR DESCRIPTION
Implements https://github.com/openmicroscopy/bio-formats-octave-docker/pull/9#issuecomment-313739523:

- removes the download of the OME sample image from `Dockerfile` 
- downloads the OME sample file in `.travis.yml` using caching
- renames `minimal_test.m` as `travis_test.m` and adds support for an input argument specifying the file name
- run tests against two files: a sample OME-TIFF and a fake file
- sets up various agents when downloading the various artifacts using `wget` steps

To test this PR, review the Travis build log, check that the OME sample file is downloaded (or cached) and that the `travis_test.m` is correctly executed.