### PR TITLE
Remove deprecated group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: required
 
-group: deprecated-2017Q2
-
 services:
   - docker
 


### PR DESCRIPTION
Following redeployment of the new [Travis images](https://blog.travis-ci.com/2017-08-29-trusty-image-updates), this PR removes the `deprecated-2017Q2` group introduced in ea1a32b1a1260f3228a5d5f21d64ff35dec9b853.

To test this PR, check Travis remains green and the tests are executed for both the OME-TIFF and the fake file.