### PR TITLE
Switch to openmicroscopy/octave:0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/octave:0.1.0
+FROM openmicroscopy/octave:0.2.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG VERSION=5.7.0


### PR DESCRIPTION
The new base image is derived from Ubuntu 16.04 which is the current LTS.

See https://github.com/openmicroscopy/octave-docker/pull/3. Travis should pass with this PR included.