### PR TITLE
Bump version to 6.0.0-m2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM sbesson/octave:0.3.0
+FROM openmicroscopy/octave:0.3.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-ARG VERSION=6.0.0-m2
+ARG VERSION=6.0.0-m3
 
 USER root
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmicroscopy/octave:0.2.0
+FROM sbesson/octave:0.3.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 ARG VERSION=6.0.0-m2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM openmicroscopy/octave:0.2.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-ARG VERSION=6.0.0-m1
+ARG VERSION=6.0.0-m2
 
 USER root
-RUN apt-get update && apt-get install -y wget unzip
+RUN apt-get update \
+    && apt-get install -y wget unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
 
 USER octave
 RUN wget --user-agent Docker downloads.openmicroscopy.org/bio-formats/$VERSION/artifacts/bioformats-octave-$VERSION.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openmicroscopy/octave:0.2.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
-ARG VERSION=5.9.2
+ARG VERSION=6.0.0-m1
 
 USER root
 RUN apt-get update && apt-get install -y wget unzip


### PR DESCRIPTION
This PR bumps the Bio-Formats version to the latest Bio-Formats 6 development milestone. As a a prerequisite to installing a Bio-Formats version which is not strictly an `x.y.z` version, it is required to use a more revent version of GNU Octave (with http://hg.savannah.gnu.org/hgweb/octave/rev/32cd60419b61 included)

The base image is switched to  Ubuntu 18.04 which installs GNU Octave 4.2.0 instead of GNU Octave 4.0.0.

--depends on https://github.com/openmicroscopy/octave-docker/pull/6