### PR TITLE
Update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Prepare data
         run: |
           mkdir data
-          touch "data/test&sizeT=3.fake"
+          wget --user-agent GHA https://downloads.openmicroscopy.org/images/OME-XML/2016-06/time-series.ome.xml && mv time-series.ome.xml data
           wget --user-agent GHA https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/tubhiswt-2D.zip && unzip tubhiswt-2D.zip && mv tubhiswt-2D data
       - name: Test
         shell: bash
         run: |
           docker run -t -v $(pwd)/data/:/data/ bio-formats-octave test.m /data/tubhiswt-2D/tubhiswt_C0.ome.tif
-          docker run -t -v $(pwd)/data/:/data/ bio-formats-octave test.m  /data/test&sizeT=3.fake
+          docker run -t -v $(pwd)/data/:/data/ bio-formats-octave test.m  /data/time-series.ome.xml
   # Push image to DockerHub
   upload:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build
         run: |
           docker build -t bio-formats-octave .


### PR DESCRIPTION
This PR replaces the usage of fake file by an ome.xml one
The fake file is not recognised in that context
The problem was noticed while testing https://github.com/ome/bioformats/pull/4130

Note that the build is green but there is an error
```
Reading series #1
    .error: octave_base_value::reshape (): wrong type argument 'octave_java'
error: called from
    bfGetPlane at line 102 column 7
    bfopen at line [15](https://github.com/ome/bio-formats-octave-docker/actions/runs/8343148427/job/22832802777?pr=57#step:5:16)5 column 13
    test_bfopen at line 6 column 6
    test at line 9 column 1
```
